### PR TITLE
Bump com.github.spotbugs from 6.0.28 to 6.1.0 (#7254)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
     id 'application'                                    // Creating application bundles
     id 'build-dashboard'                                // Produces a build report
     id 'checkstyle'                                     // Checkstyle for Java, configured further below
-    id 'com.github.spotbugs' version '6.0.28'           // Spotbugs for Java
+    id 'com.github.spotbugs' version '6.1.0'           // Spotbugs for Java
     id 'java'                                           // Core java / javac
     id 'maven-publish'                                  // Publishing to Maven Central
     id 'pmd'                                            // PMD for Java, configured further below


### PR DESCRIPTION
Bumps com.github.spotbugs from 6.0.28 to 6.1.0.

---
updated-dependencies:
- dependency-name: com.github.spotbugs dependency-type: direct:production update-type: version-update:semver-minor ...